### PR TITLE
Fix dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",
-    "node-fetch": "^3.1.1",
+    "node-fetch": "^2.6.7",
     "puppeteer": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
On January 22th, a dependabot updated the node-fetch version used in the library.

![Captura de Pantalla 2022-03-13 a la(s) 1 30 27](https://user-images.githubusercontent.com/49604336/158049915-eafa65a3-f49e-439b-90dc-22758b11530f.png)

It can be solved like this:

![Captura de Pantalla 2022-03-13 a la(s) 1 32 25](https://user-images.githubusercontent.com/49604336/158049967-ec2e856c-6221-48a6-82a7-f4b6cb418871.png)

