### PR TITLE
Add support for `baseUrl` config item

### DIFF
--- a/buildQueryString.js
+++ b/buildQueryString.js
@@ -3,14 +3,20 @@
 const buildQueryString = (query) => {
   // Sanity check
   if (
-    !query || 
-    typeof query !== 'object' || 
+    !query ||
+    typeof query !== 'object' ||
     Object.keys(query).length === 0
   ) {
     return ''
   }
-  // Build and return query string
-  return Object.keys(query).map(key => `${key}=${query[key]}`).join('&')
+  // Build query string
+  // Example: { q: 'puppies', hl: 'en', gl: 'US' } => '?q=puppies&hl=en&gl=US'
+  const queryString = Object.keys(query).reduce((acc, key, index) => {
+    const prefix = index === 0 ? '?' : '&'
+    return `${acc}${prefix}${key}=${query[key]}`
+  }, '')
+
+  return queryString
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const googleNewsScraper = async (userConfig) => {
   const queryString = config.queryVars ? buildQueryString(config.queryVars) : ''
   const baseUrl = config.baseUrl ?? `https://news.google.com/search?q=${config.searchTerm}`
   const timeString = config.timeframe ? ` when:${config.timeframe}` : ''
-  const url = `${baseUrl}}&${queryString}${timeString}`
+  const url = `${baseUrl}&${queryString}${timeString}`
 
   console.log(`📰 SCRAPING NEWS FROM: ${url}`);
   const requiredArgs = [

--- a/index.js
+++ b/index.js
@@ -14,10 +14,16 @@ const googleNewsScraper = async (userConfig) => {
     puppeteerArgs: [],
   }, userConfig);
 
-  const queryString = config.queryVars ? buildQueryString(config.queryVars) : ''
-  const baseUrl = config.baseUrl ?? `https://news.google.com/search?q=${config.searchTerm}`
+
+  let queryVars = config.queryVars || {};
+  if (config.searchTerm) {
+    queryVars.q = config.query;
+  }
+
+  const queryString = config.queryVars ? buildQueryString(queryVars) : ''
+  const baseUrl = config.baseUrl ?? `https://news.google.com/search`
   const timeString = config.timeframe ? ` when:${config.timeframe}` : ''
-  const url = `${baseUrl}&${queryString}${timeString}`
+  const url = `${baseUrl}${queryString}${timeString}`
 
   console.log(`📰 SCRAPING NEWS FROM: ${url}`);
   const requiredArgs = [

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ const googleNewsScraper = async (userConfig) => {
   const config = Object.assign({
     prettyURLs: true,
     getArticleContent: false,
-    timeframe: "7d",
     puppeteerArgs: [],
   }, userConfig);
 


### PR DESCRIPTION
This has been added so that urls such as
`https://news.google.com/topics/CAAql...`
can be crawled.

Also optimizes/simplifies some url generation items.