### PR TITLE
Allow setting puppeteer headless mode in userConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const googleNewsScraper = async (userConfig) => {
     prettyURLs: true,
     getArticleContent: false,
     puppeteerArgs: [],
+    puppeteerHeadlessMode: true,
   }, userConfig);
 
 
@@ -33,7 +34,7 @@ const googleNewsScraper = async (userConfig) => {
     '--load-extension=/path/to/manifest/folder/',
   ];
   const puppeteerConfig = {
-    headless: true,
+    headless: userConfig.puppeteerHeadlessMode,
     args: puppeteer.defaultArgs().concat(config.puppeteerArgs).filter(Boolean).concat(requiredArgs)
   }
   const browser = await puppeteer.launch(puppeteerConfig)


### PR DESCRIPTION
Using `headless: true` seems to have a significant performance impact over using `headless: 'shell'`.
There is an issue in the puppeteer repository and during some testing, I found using `shell` was around 7-8 times faster for my queries.

It would be great if one could set the puppeteer headless mode by defining it as an input argument.
 